### PR TITLE
Add basic route tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Dev environment
 pip
 autopep8
+pytest
 
 # App
 flask

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,14 @@
+import pytest
+
+from main import app
+
+@pytest.fixture()
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+@pytest.mark.parametrize('path', ['/', '/favicon.ico', '/screenshot.png', '/robots.txt'])
+def test_routes_ok(client, path):
+    response = client.get(path)
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- test HTTP 200 responses for known routes
- include pytest in requirements for dev

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'main')*

------
https://chatgpt.com/codex/tasks/task_e_684cf01620d0832cbb75433e51f77c7d