### PR TITLE
Fix default open file

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -14,7 +14,7 @@
         install =
           "python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt";
         # Open editors for the following files by default, if they exist:
-        default.openFiles = [ "README.md" "src/index.html" "main.py" ];
+        default.openFiles = [ "README.md" "gemini-live.html" "main.py" ];
       }; # To run something each time the workspace is (re)started, use the `onStart` hook
     };
     # Enable previews and customize configuration


### PR DESCRIPTION
## Summary
- open `gemini-live.html` by default instead of missing `src/index.html`

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684cf014df1c832cb878ce032f73bbfc